### PR TITLE
fix: Add package-mode = false for Poetry 2.x compatibility

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,6 +3,7 @@ name = "document-generator"
 version = "0.1.0"
 description = "Document generation testing framework"
 authors = ["Your Name <your.email@example.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
## Summary

- Fixes CI failure caused by Poetry 2.x stricter package detection
- Adds `package-mode = false` to pyproject.toml for application mode

## Problem

Poetry 2.2.1 (installed in CI) requires explicit package configuration. Without it, CI fails with:

```
Error: The current project could not be installed: No file/folder found for package document-generator
```

## Solution

Added `package-mode = false` to `backend/pyproject.toml` since this is an application, not a distributable library.

## Test plan

- [ ] CI workflow passes after merge
- [ ] Docker build continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend project configuration settings to optimize build and deployment behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->