### PR TITLE
fix: use body_path for release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,16 @@ jobs:
             echo "Initial release" > CHANGELOG.md
           fi
 
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          # Use unique delimiter for multiline output
+          DELIMITER=$(uuidgen)
+          echo "changelog<<${DELIMITER}" >> $GITHUB_OUTPUT
           cat CHANGELOG.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${DELIMITER}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          body: ${{ steps.changelog.outputs.changelog }}
+          body_path: CHANGELOG.md
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary
Fix release workflow failing with EOF delimiter error.

## Changes
Use `body_path: CHANGELOG.md` instead of passing content via GitHub output variable.

## Issue
The previous approach using heredoc syntax (`<<EOF`) was failing due to delimiter issues in the changelog content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use dynamic delimiters for changelog output, improving process robustness. Modified release step to consume changelog from file instead of inline configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->